### PR TITLE
Implement Background Clipboard Listener 

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,7 +47,10 @@ fn monitor_clipboard(app: tauri::AppHandle) {
                     }
                 } //debugging purpose
                 Err(e) => {
-                    eprintln!("Failed to read clipboard content: {}", e);
+                    if !last_clipboard_content.is_empty() {
+                        eprintln!("Failed to read clipboard content: {}", e);
+                        last_clipboard_content.clear(); // Clear the last content to avoid repeated errors
+                    }
                 }
             }
             thread::sleep(Duration::from_secs(1)); // Check every second

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,9 +42,7 @@ fn monitor_clipboard(app: tauri::AppHandle) {
         let mut last_hash: u64 = 0;
         if let Ok(initial_clipboard_content) = app.clipboard().read_text() {
             if !initial_clipboard_content.is_empty() {
-                let mut hasher = DefaultHasher::new();
-                initial_clipboard_content.hash(&mut hasher);
-                last_hash = hasher.finish();
+                last_hash = get_clipboard_content_hash(&initial_clipboard_content);
             }
         }
         // continuously monitor clipboard content changes
@@ -53,9 +51,7 @@ fn monitor_clipboard(app: tauri::AppHandle) {
                 Ok(current_clipboard_content) => {
                     let mut current_hash: u64 = 0;
                     if !current_clipboard_content.is_empty() {
-                        let mut hasher = DefaultHasher::new();
-                        current_clipboard_content.hash(&mut hasher);
-                        current_hash = hasher.finish();
+                        current_hash = get_clipboard_content_hash(&current_clipboard_content);
                     }
                     if current_clipboard_content.len() > 0 {
                         if current_hash != last_hash {
@@ -80,4 +76,10 @@ fn monitor_clipboard(app: tauri::AppHandle) {
             thread::sleep(Duration::from_secs(1)); // Check every second
         }
     });
+}
+
+fn get_clipboard_content_hash(clipboard_content: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    clipboard_content.hash(&mut hasher);
+    hasher.finish()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,6 +22,9 @@
       "csp": null
     }
   },
+  "plugins": {
+  "clipboard-manager": null
+  },
   "bundle": {
     "active": true,
     "targets": "all",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
       {
         "title": "copak",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "visible": false
       }
     ],
     "security": {


### PR DESCRIPTION
Edit tauri.conf.json to hide the main window on startup. 
Write a Rust thread/listener to poll or wait for clipboard text changes.
optimize clipboard comparison using hashing